### PR TITLE
`fallback` is not needed for `switch`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,7 @@ struct Opts {
 async fn main() -> datafusion::error::Result<()> {
     let disable_type_infer = long("disable-type-infer")
         .switch()
-        .help("Disable type inference")
-        .fallback(false);
+        .help("Disable type inference");
     let query_sql = positional::<String>("sql").fallback("SELECT * FROM stdin".to_string());
     let args_parser = construct!(Opts {
         disable_type_infer,


### PR DESCRIPTION
`switch` produces true if the flag is present and false otherwise.

What's more `fallback` works by handling "item not found" style error,
but `switch` also handles this error so it does nothing.

docs: https://docs.rs/bpaf/latest/bpaf/params/struct.NamedArg.html#method.switch
